### PR TITLE
Add udev rules currently used on tuw-robotino2 2 and 3 /3

### DIFF
--- a/setup_robotino/udev_rules/99-airskin.rules
+++ b/setup_robotino/udev_rules/99-airskin.rules
@@ -1,0 +1,1 @@
+SUBSYSTEMS=="usb", KERNEL=="ttyACM[0-9]*", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="ffee", SYMLINK+="ttyAirskin", MODE="0666"

--- a/setup_robotino/udev_rules/99-arm.rules
+++ b/setup_robotino/udev_rules/99-arm.rules
@@ -1,0 +1,2 @@
+# TUW serial number: A9IPDFB3
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="A600EPN5", SYMLINK+="ttyArm", MODE="0660", GROUP="dialout"

--- a/setup_robotino/udev_rules/99-ftdid.rules
+++ b/setup_robotino/udev_rules/99-ftdid.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="tty", KERNEL=="ttyUSB[0-9]*", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", RUN+="/usr/local/robotino/daemons/bin/ftdid -daemon -device=/dev/ttyUSB%n"

--- a/setup_robotino/udev_rules/99-hand.rules
+++ b/setup_robotino/udev_rules/99-hand.rules
@@ -1,0 +1,1 @@
+SUBSYSTEMS=="usb", KERNEL=="ttyACM[0-9]*", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="0042", ATTRS{serial}=="554323330383519041C2", SYMLINK+="ttyHand", MODE="0666"

--- a/setup_robotino/udev_rules/99-joystick.rules
+++ b/setup_robotino/udev_rules/99-joystick.rules
@@ -1,0 +1,1 @@
+KERNEL=="js0", SUBSYSTEM=="input" RUN+="/etc/init.d/joystick.sh start"

--- a/setup_robotino/udev_rules/99-laserd2.rules
+++ b/setup_robotino/udev_rules/99-laserd2.rules
@@ -1,0 +1,1 @@
+KERNEL=="ttyACM[0-9]*", SUBSYSTEM=="tty", ATTRS{idVendor}=="15d1", ATTRS{idProduct}=="0000", ATTRS{manufacturer}=="Hokuyo Data Flex for USB", ATTRS{product}=="URG-Series USB Driver", SYMLINK+="ttyScan", MODE="0660", GROUP="dialout"

--- a/setup_robotino/udev_rules/99-tilt.rules
+++ b/setup_robotino/udev_rules/99-tilt.rules
@@ -1,0 +1,2 @@
+# TUW serial number: A9IPDFB3
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="A9IPDFB3", SYMLINK+="ttyTilt", MODE="0660", GROUP="dialout"

--- a/setup_robotino/udev_rules/99-wlan.rules
+++ b/setup_robotino/udev_rules/99-wlan.rules
@@ -1,0 +1,4 @@
+# USB device 0x:0x (rtl8187)
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", KERNEL=="wlan0", RUN+="/sbin/ifup wlan0",
+SUBSYSTEM=="net", ACTION=="remove", DRIVERS=="?*", KERNEL=="wlan0", RUN+="/sbin/ifdown wlan0"
+


### PR DESCRIPTION
2/3 98-squirrelarm.rules and 99-arm.rules should do the same, shouldn't they.
99-arm is working on tuw-robotino2. Is 98-squirrelarm used anywhere?

3/3 Festo udev rules? Do we need them in the repo?
